### PR TITLE
Use published alpine container for local "quick" docker builds

### DIFF
--- a/Dockerfile_quick
+++ b/Dockerfile_quick
@@ -1,17 +1,12 @@
-ARG UBUNTU_BUILDER=ubuntu:20.04
-ARG MAINNET_RUNNER=quay.io/team-helium/blockchain-node:blockchain-node-ubuntu18-1.1.53
-ARG TESTNET_RUNNER=quay.io/team-helium/blockchain-node:blockchain-node-testnet-ubuntu18-1.1.53
+ARG BUILDER=golang:alpine3.15
+ARG MAINNET_RUNNER=quay.io/team-helium/blockchain-node:blockchain-node-1.1.56
+ARG TESTNET_RUNNER=quay.io/team-helium/blockchain-node:blockchain-node-testnet-1.1.56
 ARG NETWORK=mainnet
 
 
-FROM $UBUNTU_BUILDER as rosetta-builder
+FROM $BUILDER as rosetta-builder
 
 WORKDIR /src
-
-RUN apt update \
-      && apt install -y --no-install-recommends \
-         curl ca-certificates git \
-      && curl -L https://golang.org/dl/go1.17.1.linux-amd64.tar.gz | tar xzf -
 
 ENV PATH="/src/go/bin:$PATH" \
     CGO_ENABLED=0
@@ -44,9 +39,8 @@ FROM runner-${NETWORK} as rosetta-helium-final
 EXPOSE 8080
 EXPOSE 44158
 
-RUN apt update \
-    && apt install -y --no-install-recommends \
-         ca-certificates git npm
+RUN apk add --no-cache --update \
+    ca-certificates git npm
 
 RUN cd helium-constructor \
       && npm install \


### PR DESCRIPTION
TODO: Need to get testnet builds going on the `blockchain-node` side.